### PR TITLE
fix: CQDG-1348 Replaced abreviations with words separated by dashes

### DIFF
--- a/fsh-generated/resources/CodeSystem-experimental-strategy.json
+++ b/fsh-generated/resources/CodeSystem-experimental-strategy.json
@@ -8,12 +8,12 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy",
   "concept": [
     {
-      "code": "WXS",
+      "code": "Whole-Exome-Sequencing",
       "display": "Whole Exome Sequencing",
       "designation": [
         {
           "use": {
-            "code": "WXS",
+            "code": "Whole-Exome-Sequencing",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy"
           },
           "value": "Whole Exome Sequencing"
@@ -21,12 +21,12 @@
       ]
     },
     {
-      "code": "WGS",
+      "code": "Whole-Genome-Sequencing",
       "display": "Whole Genome Sequencing",
       "designation": [
         {
           "use": {
-            "code": "WGS",
+            "code": "Whole-Genome-Sequencing",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy"
           },
           "value": "Whole Genome Sequencing"
@@ -34,12 +34,12 @@
       ]
     },
     {
-      "code": "TARS",
+      "code": "Targeted-Sequencing",
       "display": "Targeted Sequencing",
       "designation": [
         {
           "use": {
-            "code": "TARS",
+            "code": "Targeted-Sequencing",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy"
           },
           "value": "Targeted Sequencing"

--- a/fsh-generated/resources/CodeSystem-sequencing-experiment-selection.json
+++ b/fsh-generated/resources/CodeSystem-sequencing-experiment-selection.json
@@ -21,12 +21,12 @@
       ]
     },
     {
-      "code": "RR",
+      "code": "Reduced-Representation",
       "display": "Reduced Representation",
       "designation": [
         {
           "use": {
-            "code": "RR",
+            "code": "Reduced-Representation",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection"
           },
           "value": "Reduced Representation"
@@ -86,12 +86,12 @@
       ]
     },
     {
-      "code": "HS",
+      "code": "Hybrid-Selection",
       "display": "Hybrid Selection",
       "designation": [
         {
           "use": {
-            "code": "HS",
+            "code": "Hybrid-Selection",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection"
           },
           "value": "Hybrid Selection"

--- a/fsh-generated/resources/CodeSystem-sequencing-experiment-source.json
+++ b/fsh-generated/resources/CodeSystem-sequencing-experiment-source.json
@@ -8,12 +8,12 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source",
   "concept": [
     {
-      "code": "GEN",
+      "code": "Genomic",
       "display": "Genomic",
       "designation": [
         {
           "use": {
-            "code": "GEN",
+            "code": "Genomic",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Genomic"
@@ -21,12 +21,12 @@
       ]
     },
     {
-      "code": "TSC",
+      "code": "Transcriptomic-Single-Cell",
       "display": "Transcriptomic Single Cell",
       "designation": [
         {
           "use": {
-            "code": "TSC",
+            "code": "Transcriptomic-Single-Cell",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Transcriptomic Single Cell"
@@ -34,12 +34,12 @@
       ]
     },
     {
-      "code": "TS",
+      "code": "Transcriptomic",
       "display": "Transcriptomic",
       "designation": [
         {
           "use": {
-            "code": "TS",
+            "code": "Transcriptomic",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Transcriptomic"
@@ -47,12 +47,12 @@
       ]
     },
     {
-      "code": "GSC",
+      "code": "Genomic-Single-Cell",
       "display": "Genomic Single Cell",
       "designation": [
         {
           "use": {
-            "code": "GSC",
+            "code": "Genomic-Single-Cell",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Genomic Single Cell"

--- a/fsh-generated/resources/Task-CQDGTaskExample.json
+++ b/fsh-generated/resources/Task-CQDGTaskExample.json
@@ -33,7 +33,7 @@
         {
           "url": "experimentalStrategy",
           "valueCoding": {
-            "code": "WXS",
+            "code": "Whole-Exome-Sequencing",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy",
             "display": "Whole Exome Sequencing"
           }
@@ -65,7 +65,7 @@
         {
           "url": "source",
           "valueCoding": {
-            "code": "GEN",
+            "code": "Genomic",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source",
             "display": "Genomic"
           }

--- a/input/fsh/TaskResource/CQDG_Profile_Task_Example.fsh
+++ b/input/fsh/TaskResource/CQDG_Profile_Task_Example.fsh
@@ -9,13 +9,13 @@ Usage: #example
 * extension[workflowExtension].extension[pipeline][0].valueString = "First Pipeline"
 * extension[workflowExtension].extension[pipeline][+].valueString = "Second Pipeline"
 
-* extension[sequencingExperimentExtension].extension[experimentalStrategy].valueCoding = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#WXS "Whole Exome Sequencing"
+* extension[sequencingExperimentExtension].extension[experimentalStrategy].valueCoding = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Whole-Exome-Sequencing "Whole Exome Sequencing"
 * extension[sequencingExperimentExtension].extension[isPairedEnd].valueBoolean = true
 * extension[sequencingExperimentExtension].extension[platform].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-platform#Illumina "Illumina"
 * extension[sequencingExperimentExtension].extension[protocol].valueString = "protocol2"
 * extension[sequencingExperimentExtension].extension[readLength].valueString = "151,8,8,151"
 * extension[sequencingExperimentExtension].extension[selection].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#CHIP "ChIP"
-* extension[sequencingExperimentExtension].extension[source].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#GEN "Genomic"
+* extension[sequencingExperimentExtension].extension[source].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Genomic "Genomic"
 * extension[sequencingExperimentExtension].extension[targetCaptureKit].valueString = "targetCaptureKit2"
 * extension[sequencingExperimentExtension].extension[targetLoci].valueString = "targetedLoci2"
 * extension[sequencingExperimentExtension].extension[runIds][0].valueString = "RunID12345"

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_ExperimentalStrategy.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_ExperimentalStrategy.fsh
@@ -7,17 +7,17 @@ Title: "Ferlab.bio CodeSystem/experimental-strategy"
 * ^description = "Experimental strategy"
 * ^caseSensitive = true
 
-* #"WXS" "Whole Exome Sequencing"
-* #"WXS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#WXS
-* #"WXS" ^designation.value = "Whole Exome Sequencing"
+* #"Whole-Exome-Sequencing" "Whole Exome Sequencing"
+* #"Whole-Exome-Sequencing" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Whole-Exome-Sequencing
+* #"Whole-Exome-Sequencing" ^designation.value = "Whole Exome Sequencing"
 
-* #"WGS" "Whole Genome Sequencing"
-* #"WGS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#WGS
-* #"WGS" ^designation.value = "Whole Genome Sequencing"
+* #"Whole-Genome-Sequencing" "Whole Genome Sequencing"
+* #"Whole-Genome-Sequencing" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Whole-Genome-Sequencing
+* #"Whole-Genome-Sequencing" ^designation.value = "Whole Genome Sequencing"
 
-* #"TARS" "Targeted Sequencing"
-* #"TARS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#TARS
-* #"TARS" ^designation.value = "Targeted Sequencing"
+* #"Targeted-Sequencing" "Targeted Sequencing"
+* #"Targeted-Sequencing" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Targeted-Sequencing
+* #"Targeted-Sequencing" ^designation.value = "Targeted Sequencing"
 
 * #"RNAS" "RNA-Seq"
 * #"RNAS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#RNAS

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-selection.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-selection.fsh
@@ -11,9 +11,9 @@ Title: "Ferlab.bio CodeSystem/sequencing-experiment-selection"
 * #"CHIP" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#CHIP
 * #"CHIP" ^designation.value = "ChIP"
 
-* #"RR" "Reduced Representation"
-* #"RR" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#RR
-* #"RR" ^designation.value = "Reduced Representation"
+* #"Reduced-Representation" "Reduced Representation"
+* #"Reduced-Representation" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#Reduced-Representation
+* #"Reduced-Representation" ^designation.value = "Reduced Representation"
 
 * #"RANDOM" "Random"
 * #"RANDOM" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#RANDOM
@@ -31,6 +31,6 @@ Title: "Ferlab.bio CodeSystem/sequencing-experiment-selection"
 * #"ODT" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#ODT
 * #"ODT" ^designation.value = "Oligo-dT"
 
-* #"HS" "Hybrid Selection"
-* #"HS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#HS
-* #"HS" ^designation.value = "Hybrid Selection"
+* #"Hybrid-Selection" "Hybrid Selection"
+* #"Hybrid-Selection" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#Hybrid-Selection
+* #"Hybrid-Selection" ^designation.value = "Hybrid Selection"

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-source.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-source.fsh
@@ -7,18 +7,18 @@ Title: "Ferlab.bio CodeSystem/sequencing-experiment-source"
 * ^description = "Sequencing experimental source"
 * ^caseSensitive = true
 
-* #"GEN" "Genomic"
-* #"GEN" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#GEN
-* #"GEN" ^designation.value = "Genomic"
+* #"Genomic" "Genomic"
+* #"Genomic" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Genomic
+* #"Genomic" ^designation.value = "Genomic"
 
-* #"TSC" "Transcriptomic Single Cell"
-* #"TSC" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#TSC
-* #"TSC" ^designation.value = "Transcriptomic Single Cell"
+* #"Transcriptomic-Single-Cell" "Transcriptomic Single Cell"
+* #"Transcriptomic-Single-Cell" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Transcriptomic-Single-Cell
+* #"Transcriptomic-Single-Cell" ^designation.value = "Transcriptomic Single Cell"
 
-* #"TS" "Transcriptomic"
-* #"TS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#TS
-* #"TS" ^designation.value = "Transcriptomic"
+* #"Transcriptomic" "Transcriptomic"
+* #"Transcriptomic" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Transcriptomic
+* #"Transcriptomic" ^designation.value = "Transcriptomic"
 
-* #"GSC" "Genomic Single Cell"
-* #"GSC" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#GSC
-* #"GSC" ^designation.value = "Genomic Single Cell"
+* #"Genomic-Single-Cell" "Genomic Single Cell"
+* #"Genomic-Single-Cell" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Genomic-Single-Cell
+* #"Genomic-Single-Cell" ^designation.value = "Genomic Single Cell"


### PR DESCRIPTION
## Context
Some Code Systems are set as abreviations in the FHIR IG (`experimental-strategy`, `source` and `selection`) but are full words with spaces when in the metadata file. The FHIR definitions need to use the words with dashes instead of spaces.
## Jira
- [CQDG-1348](https://ferlab-crsj.atlassian.net/browse/CQDG-1348?atlOrigin=eyJpIjoiMjU5OWYzOGVjNTUzNDgyYmJlZjQxOTQ3OTI4MjEzYzciLCJwIjoiaiJ9)

[CQDG-1348]: https://ferlab-crsj.atlassian.net/browse/CQDG-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ