### PR TITLE
feat: CQDG-1351 Rolledback to using abbreviations for seq exp code systems

### DIFF
--- a/fsh-generated/resources/CodeSystem-experimental-strategy.json
+++ b/fsh-generated/resources/CodeSystem-experimental-strategy.json
@@ -8,12 +8,12 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy",
   "concept": [
     {
-      "code": "Whole-Exome-Sequencing",
+      "code": "WXS",
       "display": "Whole Exome Sequencing",
       "designation": [
         {
           "use": {
-            "code": "Whole-Exome-Sequencing",
+            "code": "WXS",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy"
           },
           "value": "Whole Exome Sequencing"
@@ -21,12 +21,12 @@
       ]
     },
     {
-      "code": "Whole-Genome-Sequencing",
+      "code": "WGS",
       "display": "Whole Genome Sequencing",
       "designation": [
         {
           "use": {
-            "code": "Whole-Genome-Sequencing",
+            "code": "WGS",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy"
           },
           "value": "Whole Genome Sequencing"
@@ -34,12 +34,12 @@
       ]
     },
     {
-      "code": "Targeted-Sequencing",
+      "code": "TARS",
       "display": "Targeted Sequencing",
       "designation": [
         {
           "use": {
-            "code": "Targeted-Sequencing",
+            "code": "TARS",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy"
           },
           "value": "Targeted Sequencing"

--- a/fsh-generated/resources/CodeSystem-sequencing-experiment-selection.json
+++ b/fsh-generated/resources/CodeSystem-sequencing-experiment-selection.json
@@ -21,12 +21,12 @@
       ]
     },
     {
-      "code": "Reduced-Representation",
+      "code": "RR",
       "display": "Reduced Representation",
       "designation": [
         {
           "use": {
-            "code": "Reduced-Representation",
+            "code": "RR",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection"
           },
           "value": "Reduced Representation"
@@ -86,12 +86,12 @@
       ]
     },
     {
-      "code": "Hybrid-Selection",
+      "code": "HS",
       "display": "Hybrid Selection",
       "designation": [
         {
           "use": {
-            "code": "Hybrid-Selection",
+            "code": "HS",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection"
           },
           "value": "Hybrid Selection"

--- a/fsh-generated/resources/CodeSystem-sequencing-experiment-source.json
+++ b/fsh-generated/resources/CodeSystem-sequencing-experiment-source.json
@@ -8,12 +8,12 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source",
   "concept": [
     {
-      "code": "Genomic",
+      "code": "GEN",
       "display": "Genomic",
       "designation": [
         {
           "use": {
-            "code": "Genomic",
+            "code": "GEN",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Genomic"
@@ -21,12 +21,12 @@
       ]
     },
     {
-      "code": "Transcriptomic-Single-Cell",
+      "code": "TSC",
       "display": "Transcriptomic Single Cell",
       "designation": [
         {
           "use": {
-            "code": "Transcriptomic-Single-Cell",
+            "code": "TSC",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Transcriptomic Single Cell"
@@ -34,12 +34,12 @@
       ]
     },
     {
-      "code": "Transcriptomic",
+      "code": "TS",
       "display": "Transcriptomic",
       "designation": [
         {
           "use": {
-            "code": "Transcriptomic",
+            "code": "TS",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Transcriptomic"
@@ -47,12 +47,12 @@
       ]
     },
     {
-      "code": "Genomic-Single-Cell",
+      "code": "GSC",
       "display": "Genomic Single Cell",
       "designation": [
         {
           "use": {
-            "code": "Genomic-Single-Cell",
+            "code": "GSC",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source"
           },
           "value": "Genomic Single Cell"

--- a/fsh-generated/resources/Task-CQDGTaskExample.json
+++ b/fsh-generated/resources/Task-CQDGTaskExample.json
@@ -33,7 +33,7 @@
         {
           "url": "experimentalStrategy",
           "valueCoding": {
-            "code": "Whole-Exome-Sequencing",
+            "code": "WGS",
             "system": "https://fhir.cqdg.ca/CodeSystem/experimental-strategy",
             "display": "Whole Exome Sequencing"
           }
@@ -65,7 +65,7 @@
         {
           "url": "source",
           "valueCoding": {
-            "code": "Genomic",
+            "code": "GEN",
             "system": "https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source",
             "display": "Genomic"
           }

--- a/input/fsh/TaskResource/CQDG_Profile_Task_Example.fsh
+++ b/input/fsh/TaskResource/CQDG_Profile_Task_Example.fsh
@@ -9,13 +9,13 @@ Usage: #example
 * extension[workflowExtension].extension[pipeline][0].valueString = "First Pipeline"
 * extension[workflowExtension].extension[pipeline][+].valueString = "Second Pipeline"
 
-* extension[sequencingExperimentExtension].extension[experimentalStrategy].valueCoding = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Whole-Exome-Sequencing "Whole Exome Sequencing"
+* extension[sequencingExperimentExtension].extension[experimentalStrategy].valueCoding = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#WGS "Whole Exome Sequencing"
 * extension[sequencingExperimentExtension].extension[isPairedEnd].valueBoolean = true
 * extension[sequencingExperimentExtension].extension[platform].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-platform#Illumina "Illumina"
 * extension[sequencingExperimentExtension].extension[protocol].valueString = "protocol2"
 * extension[sequencingExperimentExtension].extension[readLength].valueString = "151,8,8,151"
 * extension[sequencingExperimentExtension].extension[selection].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#CHIP "ChIP"
-* extension[sequencingExperimentExtension].extension[source].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Genomic "Genomic"
+* extension[sequencingExperimentExtension].extension[source].valueCoding = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#GEN "Genomic"
 * extension[sequencingExperimentExtension].extension[targetCaptureKit].valueString = "targetCaptureKit2"
 * extension[sequencingExperimentExtension].extension[targetLoci].valueString = "targetedLoci2"
 * extension[sequencingExperimentExtension].extension[runIds][0].valueString = "RunID12345"

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_ExperimentalStrategy.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_ExperimentalStrategy.fsh
@@ -7,17 +7,17 @@ Title: "Ferlab.bio CodeSystem/experimental-strategy"
 * ^description = "Experimental strategy"
 * ^caseSensitive = true
 
-* #"Whole-Exome-Sequencing" "Whole Exome Sequencing"
-* #"Whole-Exome-Sequencing" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Whole-Exome-Sequencing
-* #"Whole-Exome-Sequencing" ^designation.value = "Whole Exome Sequencing"
+* #"WXS" "Whole Exome Sequencing"
+* #"WXS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#WXS
+* #"WXS" ^designation.value = "Whole Exome Sequencing"
 
-* #"Whole-Genome-Sequencing" "Whole Genome Sequencing"
-* #"Whole-Genome-Sequencing" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Whole-Genome-Sequencing
-* #"Whole-Genome-Sequencing" ^designation.value = "Whole Genome Sequencing"
+* #"WGS" "Whole Genome Sequencing"
+* #"WGS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#WGS
+* #"WGS" ^designation.value = "Whole Genome Sequencing"
 
-* #"Targeted-Sequencing" "Targeted Sequencing"
-* #"Targeted-Sequencing" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#Targeted-Sequencing
-* #"Targeted-Sequencing" ^designation.value = "Targeted Sequencing"
+* #"TARS" "Targeted Sequencing"
+* #"TARS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#TARS
+* #"TARS" ^designation.value = "Targeted Sequencing"
 
 * #"RNAS" "RNA-Seq"
 * #"RNAS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/experimental-strategy#RNAS

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-selection.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-selection.fsh
@@ -11,9 +11,9 @@ Title: "Ferlab.bio CodeSystem/sequencing-experiment-selection"
 * #"CHIP" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#CHIP
 * #"CHIP" ^designation.value = "ChIP"
 
-* #"Reduced-Representation" "Reduced Representation"
-* #"Reduced-Representation" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#Reduced-Representation
-* #"Reduced-Representation" ^designation.value = "Reduced Representation"
+* #"RR" "Reduced Representation"
+* #"RR" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#RR
+* #"RR" ^designation.value = "Reduced Representation"
 
 * #"RANDOM" "Random"
 * #"RANDOM" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#RANDOM
@@ -31,6 +31,6 @@ Title: "Ferlab.bio CodeSystem/sequencing-experiment-selection"
 * #"ODT" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#ODT
 * #"ODT" ^designation.value = "Oligo-dT"
 
-* #"Hybrid-Selection" "Hybrid Selection"
-* #"Hybrid-Selection" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#Hybrid-Selection
-* #"Hybrid-Selection" ^designation.value = "Hybrid Selection"
+* #"HS" "Hybrid Selection"
+* #"HS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-selection#HS
+* #"HS" ^designation.value = "Hybrid Selection"

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-source.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_Sequencing-experiment-source.fsh
@@ -7,18 +7,18 @@ Title: "Ferlab.bio CodeSystem/sequencing-experiment-source"
 * ^description = "Sequencing experimental source"
 * ^caseSensitive = true
 
-* #"Genomic" "Genomic"
-* #"Genomic" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Genomic
-* #"Genomic" ^designation.value = "Genomic"
+* #"GEN" "Genomic"
+* #"GEN" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#GEN
+* #"GEN" ^designation.value = "Genomic"
 
-* #"Transcriptomic-Single-Cell" "Transcriptomic Single Cell"
-* #"Transcriptomic-Single-Cell" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Transcriptomic-Single-Cell
-* #"Transcriptomic-Single-Cell" ^designation.value = "Transcriptomic Single Cell"
+* #"TSC" "Transcriptomic Single Cell"
+* #"TSC" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#TSC
+* #"TSC" ^designation.value = "Transcriptomic Single Cell"
 
-* #"Transcriptomic" "Transcriptomic"
-* #"Transcriptomic" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Transcriptomic
-* #"Transcriptomic" ^designation.value = "Transcriptomic"
+* #"TS" "Transcriptomic"
+* #"TS" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#TS
+* #"TS" ^designation.value = "Transcriptomic"
 
-* #"Genomic-Single-Cell" "Genomic Single Cell"
-* #"Genomic-Single-Cell" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#Genomic-Single-Cell
-* #"Genomic-Single-Cell" ^designation.value = "Genomic Single Cell"
+* #"GSC" "Genomic Single Cell"
+* #"GSC" ^designation.use = https://fhir.cqdg.ca/CodeSystem/sequencing-experiment-source#GSC
+* #"GSC" ^designation.value = "Genomic Single Cell"


### PR DESCRIPTION
Instead the mapping to abbreviations will be done on the `cqdg-fhir-import` side.

Related ticket : [CQDG-1351](https://ferlab-crsj.atlassian.net/browse/CQDG-1351?atlOrigin=eyJpIjoiZmExYmNjZDMxMjIzNDczYjkyYTZkOWZlZWY4ZDczNWMiLCJwIjoiaiJ9)

Related PR : [here](https://github.com/Ferlab-Ste-Justine/cqdg-fhir-import/pull/55)

[CQDG-1351]: https://ferlab-crsj.atlassian.net/browse/CQDG-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ