### PR TITLE
feat: CQDG-1375 Updated code systems for DocumentReference

### DIFF
--- a/fsh-generated/data/fsh-index.json
+++ b/fsh-generated/data/fsh-index.json
@@ -13,7 +13,7 @@
     "fshType": "CodeSystem",
     "fshFile": "TaskResource/CodeSystems/CQDG_CodeSystem_BioinfoAnalysisCode.fsh",
     "startLine": 1,
-    "endLine": 22
+    "endLine": 20
   },
   {
     "outputFile": "CodeSystem-cause-of-death-codes.json",
@@ -85,7 +85,7 @@
     "fshType": "CodeSystem",
     "fshFile": "DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh",
     "startLine": 1,
-    "endLine": 48
+    "endLine": 68
   },
   {
     "outputFile": "CodeSystem-disease-status.json",

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -1,6 +1,6 @@
 Output File                                                     Name                                      Type        FSH File                                                                          Lines
 CodeSystem-age-at-onset.json                                    AgeAtOnset                                CodeSystem  Common/CQDG_CodeSystem_AgeAtOnset.fsh                                             1 - 45
-CodeSystem-bioinfo-analysis-code.json                           BioinfoAnalysisCode                       CodeSystem  TaskResource/CodeSystems/CQDG_CodeSystem_BioinfoAnalysisCode.fsh                  1 - 22
+CodeSystem-bioinfo-analysis-code.json                           BioinfoAnalysisCode                       CodeSystem  TaskResource/CodeSystems/CQDG_CodeSystem_BioinfoAnalysisCode.fsh                  1 - 20
 CodeSystem-cause-of-death-codes.json                            CauseOfDeathCodes                         CodeSystem  ObservationResource/CodeSystems/CQDG_CodeSystem_CauseOfDeath.fsh                  1 - 41
 CodeSystem-cqdg-dataset-cs.json                                 CQDGDatasetCS                             CodeSystem  Common/CQDG_CodeSystem_Dataset.fsh                                                1 - 7
 CodeSystem-cqdg-observation-code.json                           CQDGObservationCode                       CodeSystem  ObservationResource/CodeSystems/CQDG_CodeSystem_ObservationCode.fsh               1 - 30
@@ -9,7 +9,7 @@ CodeSystem-cqdg-study-cs.json                                   CQDGStudyCS     
 CodeSystem-cqdg-tumor-normal-designation.json                   CQDGTumorNormalDesignationCodeSystem      CodeSystem  SpecimenResource/CodeSytem/CQDG_CodeSystem_TumorNormalDesignation.fsh             1 - 11
 CodeSystem-data-category.json                                   DataCategory                              CodeSystem  Common/CQDG_CodeSystem_DataCategory.fsh                                           1 - 43
 CodeSystem-data-collection-method.json                          DataCollectionMethod                      CodeSystem  ResearchStudyResource/CodeSystem/CQDG_CodeSystem_DataCollectionMethod.fsh         1 - 23
-CodeSystem-data-type.json                                       DataType                                  CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh                1 - 48
+CodeSystem-data-type.json                                       DataType                                  CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh                1 - 68
 CodeSystem-disease-status.json                                  DiseaseStatusCS                           CodeSystem  ObservationResource/CodeSystems/CQDG_CodeSystem_DiseaseStatus.fsh                 1 - 20
 CodeSystem-document-format.json                                 DocumentFormat                            CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh          1 - 52
 CodeSystem-duo-codes.json                                       DUOCodes                                  CodeSystem  ResearchStudyResource/CodeSystem/CQDG_CodeSystem_DUOCodes.fsh                     1 - 78

--- a/fsh-generated/resources/CodeSystem-data-type.json
+++ b/fsh-generated/resources/CodeSystem-data-type.json
@@ -8,25 +8,51 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/data-type",
   "concept": [
     {
-      "code": "Unaligned-Reads",
-      "display": "Unaligned Reads",
+      "code": "Raw-Sequencing-Reads",
+      "display": "Raw Sequencing Reads",
       "designation": [
         {
           "use": {
-            "code": "Unaligned-Reads",
+            "code": "Raw-Sequencing-Reads",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "Unaligned Reads"
+          "value": "Raw Sequencing Reads"
         }
       ]
     },
     {
-      "code": "Aligned-reads",
+      "code": "Raw-Sequencing-Reads-R1",
+      "display": "Raw Sequencing Reads R1",
+      "designation": [
+        {
+          "use": {
+            "code": "Raw-Sequencing-Reads-R1",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "Raw Sequencing Reads R1"
+        }
+      ]
+    },
+    {
+      "code": "Raw-Sequencing-Reads-R2",
+      "display": "Raw Sequencing Reads R2",
+      "designation": [
+        {
+          "use": {
+            "code": "Raw-Sequencing-Reads-R2",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "Raw Sequencing Reads R2"
+        }
+      ]
+    },
+    {
+      "code": "Aligned-Reads",
       "display": "Aligned Reads",
       "designation": [
         {
           "use": {
-            "code": "Aligned-reads",
+            "code": "Aligned-Reads",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
           "value": "Aligned Reads"
@@ -34,93 +60,93 @@
       ]
     },
     {
+      "code": "Aligned-Reads-Index",
+      "display": "Aligned Reads Index",
+      "designation": [
+        {
+          "use": {
+            "code": "Aligned-Reads-Index",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "Aligned Reads Index"
+        }
+      ]
+    },
+    {
       "code": "SNV",
-      "display": "SNV",
+      "display": "Single Nucleotide Variants (SNVs)",
       "designation": [
         {
           "use": {
             "code": "SNV",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "SNV"
+          "value": "Single Nucleotide Variants (SNVs)"
         }
       ]
     },
     {
-      "code": "Germline-CNV",
-      "display": "Germline CNV",
+      "code": "InDel",
+      "display": "Insertions and Deletions (InDels)",
       "designation": [
         {
           "use": {
-            "code": "Germline-CNV",
+            "code": "InDel",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "Germline CNV"
+          "value": "Insertions and Deletions (InDels)"
         }
       ]
     },
     {
-      "code": "Sequencing-data-supplement",
-      "display": "Supplement",
+      "code": "SV",
+      "display": "Structural Variations (SVs)",
       "designation": [
         {
           "use": {
-            "code": "Sequencing-data-supplement",
+            "code": "SV",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "Supplement"
+          "value": "Structural Variations (SVs)"
         }
       ]
     },
     {
-      "code": "Metrics",
-      "display": "Metrics",
+      "code": "CNV",
+      "display": "Copy Number Variations (CNVs)",
       "designation": [
         {
           "use": {
-            "code": "Metrics",
+            "code": "CNV",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "Metrics"
+          "value": "Copy Number Variations (CNVs)"
         }
       ]
     },
     {
-      "code": "Sequencing-data-index",
-      "display": "Sequencing Data Index",
+      "code": "Variant-Calls-Index",
+      "display": "Variant Calls Index",
       "designation": [
         {
           "use": {
-            "code": "Sequencing-data-index",
+            "code": "Variant-Calls-Index",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "Sequencing Data Index"
+          "value": "Variant Calls Index"
         }
       ]
     },
     {
-      "code": "Germline-structural-variant",
-      "display": "Germline Structural Variant",
+      "code": "Joint-Genotype-SNV",
+      "display": "Joint Genotype SNV",
       "designation": [
         {
           "use": {
-            "code": "Germline-structural-variant",
+            "code": "Joint-Genotype-SNV",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
-          "value": "Germline Structural Variant"
-        }
-      ]
-    },
-    {
-      "code": "IGV",
-      "display": "IGV",
-      "designation": [
-        {
-          "use": {
-            "code": "IGV",
-            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
-          },
-          "value": "IGV"
+          "value": "Joint Genotype SNV"
         }
       ]
     },
@@ -136,10 +162,49 @@
           "value": "Annotated SNV"
         }
       ]
+    },
+    {
+      "code": "QC-Metrics",
+      "display": "Quality Control Metrics",
+      "designation": [
+        {
+          "use": {
+            "code": "QC-Metrics",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "Quality Control Metrics"
+        }
+      ]
+    },
+    {
+      "code": "Sequencing-Data-Supplement",
+      "display": "Sequencing Data Supplement",
+      "designation": [
+        {
+          "use": {
+            "code": "Sequencing-Data-Supplement",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "Sequencing Data Supplement"
+        }
+      ]
+    },
+    {
+      "code": "IGV",
+      "display": "IGV",
+      "designation": [
+        {
+          "use": {
+            "code": "IGV",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "IGV"
+        }
+      ]
     }
   ],
   "experimental": false,
   "description": "Data Type",
   "caseSensitive": true,
-  "count": 10
+  "count": 15
 }

--- a/fsh-generated/resources/CodeSystem-data-type.json
+++ b/fsh-generated/resources/CodeSystem-data-type.json
@@ -164,12 +164,12 @@
       ]
     },
     {
-      "code": "QC-Metrics",
+      "code": "Quality-Control-Metrics",
       "display": "Quality Control Metrics",
       "designation": [
         {
           "use": {
-            "code": "QC-Metrics",
+            "code": "Quality-Control-Metrics",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
           },
           "value": "Quality Control Metrics"

--- a/fsh-generated/resources/CodeSystem-document-format.json
+++ b/fsh-generated/resources/CodeSystem-document-format.json
@@ -8,6 +8,16 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/document-format",
   "concept": [
     {
+      "code": "FASTQ",
+      "display": "FASTQ File",
+      "designation": [
+        {
+          "language": "fr",
+          "value": "FASTQ"
+        }
+      ]
+    },
+    {
       "code": "CRAM",
       "display": "CRAM",
       "designation": [
@@ -58,16 +68,6 @@
       ]
     },
     {
-      "code": "TGZ",
-      "display": "TGZ Archive File",
-      "designation": [
-        {
-          "language": "fr",
-          "value": "TGZ"
-        }
-      ]
-    },
-    {
       "code": "gVCF",
       "display": "gVCF File",
       "designation": [
@@ -88,12 +88,22 @@
       ]
     },
     {
-      "code": "BW",
-      "display": "BW File",
+      "code": "TGZ",
+      "display": "TGZ Archive File",
       "designation": [
         {
           "language": "fr",
-          "value": "BW"
+          "value": "TGZ"
+        }
+      ]
+    },
+    {
+      "code": "bigWig",
+      "display": "bigWig File",
+      "designation": [
+        {
+          "language": "fr",
+          "value": "bigWig"
         }
       ]
     },
@@ -104,16 +114,6 @@
         {
           "language": "fr",
           "value": "BED"
-        }
-      ]
-    },
-    {
-      "code": "FASTQ",
-      "display": "FASTQ File",
-      "designation": [
-        {
-          "language": "fr",
-          "value": "FASTQ"
         }
       ]
     }

--- a/fsh-generated/resources/DocumentReference-DocumentReferenceExample1.json
+++ b/fsh-generated/resources/DocumentReference-DocumentReferenceExample1.json
@@ -43,7 +43,7 @@
   "type": {
     "coding": [
       {
-        "code": "Sequencing-data-supplement",
+        "code": "Sequencing-Data-Supplement",
         "system": "https://fhir.cqdg.ca/CodeSystem/data-type",
         "display": "Sequencing Data Supplement"
       }

--- a/fsh-generated/resources/DocumentReference-DocumentReferenceExample2.json
+++ b/fsh-generated/resources/DocumentReference-DocumentReferenceExample2.json
@@ -40,7 +40,7 @@
   "type": {
     "coding": [
       {
-        "code": "Aligned-reads",
+        "code": "Aligned-Reads",
         "system": "https://fhir.cqdg.ca/CodeSystem/data-type",
         "display": "Aligned Reads"
       }

--- a/fsh-generated/resources/Task-CQDGTaskExample.json
+++ b/fsh-generated/resources/Task-CQDGTaskExample.json
@@ -153,7 +153,7 @@
       "type": {
         "coding": [
           {
-            "code": "Aligned-reads",
+            "code": "Aligned-Reads",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type",
             "display": "Aligned Reads"
           }
@@ -181,9 +181,9 @@
       "type": {
         "coding": [
           {
-            "code": "Germline-CNV",
+            "code": "CNV",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type",
-            "display": "Germline CNV"
+            "display": "Copy Number Variations (CNVs)"
           }
         ]
       },
@@ -195,9 +195,9 @@
       "type": {
         "coding": [
           {
-            "code": "Sequencing-data-supplement",
+            "code": "Sequencing-Data-Supplement",
             "system": "https://fhir.cqdg.ca/CodeSystem/data-type",
-            "display": "Sequencing-data-supplement"
+            "display": "Sequencing Data Supplement"
           }
         ]
       },

--- a/input/fsh/DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh
+++ b/input/fsh/DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh
@@ -11,7 +11,7 @@ Usage: #example
 * securityLabel.coding[0].display = "test"
 
 * status = #current
-* type = https://fhir.cqdg.ca/CodeSystem/data-type#"Sequencing-data-supplement" "Sequencing Data Supplement"
+* type = https://fhir.cqdg.ca/CodeSystem/data-type#"Sequencing-Data-Supplement" "Sequencing Data Supplement"
 * category = https://fhir.cqdg.ca/CodeSystem/data-category#genomics "Genomics"
 * subject = Reference(Patient/PatientExample)
 * content.attachment.extension[FullSizeExtension].valueDecimal
@@ -34,7 +34,7 @@ Usage: #example
 * securityLabel.coding[0].display = "test"
 
 * status = #current
-* type = https://fhir.cqdg.ca/CodeSystem/data-type#"Aligned-reads" "Aligned Reads"
+* type = https://fhir.cqdg.ca/CodeSystem/data-type#"Aligned-Reads" "Aligned Reads"
 * category = https://fhir.cqdg.ca/CodeSystem/data-category#genomics "Genomics"
 * subject = Reference(Patient/PatientExample)
 * content.attachment.extension[FullSizeExtension].valueDecimal = 22799222

--- a/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh
+++ b/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh
@@ -7,42 +7,62 @@ Title: "Ferlab.bio CodeSystem/data-type"
 * ^description = "Data Type"
 * ^caseSensitive = true
 
-* #"Unaligned-Reads" "Unaligned Reads"
-* #"Unaligned-Reads" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Unaligned-Reads
-* #"Unaligned-Reads" ^designation.value = "Unaligned Reads"
+* #"Raw-Sequencing-Reads" "Raw Sequencing Reads"
+* #"Raw-Sequencing-Reads" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Raw-Sequencing-Reads
+* #"Raw-Sequencing-Reads" ^designation.value = "Raw Sequencing Reads"
 
-* #"Aligned-reads" "Aligned Reads"
-* #"Aligned-reads" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Aligned-reads
-* #"Aligned-reads" ^designation.value = "Aligned Reads"
+* #"Raw-Sequencing-Reads-R1" "Raw Sequencing Reads R1"
+* #"Raw-Sequencing-Reads-R1" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Raw-Sequencing-Reads-R1
+* #"Raw-Sequencing-Reads-R1" ^designation.value = "Raw Sequencing Reads R1"
 
-* #"SNV" "SNV"
+* #"Raw-Sequencing-Reads-R2" "Raw Sequencing Reads R2"
+* #"Raw-Sequencing-Reads-R2" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Raw-Sequencing-Reads-R2
+* #"Raw-Sequencing-Reads-R2" ^designation.value = "Raw Sequencing Reads R2"
+
+* #"Aligned-Reads" "Aligned Reads"
+* #"Aligned-Reads" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Aligned-Reads
+* #"Aligned-Reads" ^designation.value = "Aligned Reads"
+
+* #"Aligned-Reads-Index" "Aligned Reads Index"
+* #"Aligned-Reads-Index" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Aligned-Reads-Index
+* #"Aligned-Reads-Index" ^designation.value = "Aligned Reads Index"
+
+* #"SNV" "Single Nucleotide Variants (SNVs)"
 * #"SNV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#SNV
-* #"SNV" ^designation.value = "SNV"
+* #"SNV" ^designation.value = "Single Nucleotide Variants (SNVs)"
 
-* #"Germline-CNV" "Germline CNV"
-* #"Germline-CNV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Germline-CNV
-* #"Germline-CNV" ^designation.value = "Germline CNV"
+* #"InDel" "Insertions and Deletions (InDels)"
+* #"InDel" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#InDel
+* #"InDel" ^designation.value = "Insertions and Deletions (InDels)"
 
-* #"Sequencing-data-supplement" "Supplement"
-* #"Sequencing-data-supplement" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Sequencing-data-supplement
-* #"Sequencing-data-supplement" ^designation.value = "Supplement"
+* #"SV" "Structural Variations (SVs)"
+* #"SV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#SV
+* #"SV" ^designation.value = "Structural Variations (SVs)"
 
-* #"Metrics" "Metrics"
-* #"Metrics" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Metrics
-* #"Metrics" ^designation.value = "Metrics"
+* #"CNV" "Copy Number Variations (CNVs)"
+* #"CNV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#CNV
+* #"CNV" ^designation.value = "Copy Number Variations (CNVs)"
 
-* #"Sequencing-data-index" "Sequencing Data Index"
-* #"Sequencing-data-index" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Sequencing-data-index
-* #"Sequencing-data-index" ^designation.value = "Sequencing Data Index"
+* #"Variant-Calls-Index" "Variant Calls Index"
+* #"Variant-Calls-Index" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Variant-Calls-Index
+* #"Variant-Calls-Index" ^designation.value = "Variant Calls Index"
 
-* #"Germline-structural-variant" "Germline Structural Variant"
-* #"Germline-structural-variant" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Germline-structural-variant
-* #"Germline-structural-variant" ^designation.value = "Germline Structural Variant"
-
-* #"IGV" "IGV"
-* #"IGV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#IGV
-* #"IGV" ^designation.value = "IGV"
+* #"Joint-Genotype-SNV" "Joint Genotype SNV"
+* #"Joint-Genotype-SNV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Joint-Genotype-SNV
+* #"Joint-Genotype-SNV" ^designation.value = "Joint Genotype SNV"
 
 * #"Annotated-SNV" "Annotated SNV"
 * #"Annotated-SNV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Annotated-SNV
 * #"Annotated-SNV" ^designation.value = "Annotated SNV"
+
+* #"QC-Metrics" "Quality Control Metrics"
+* #"QC-Metrics" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#QC-Metrics
+* #"QC-Metrics" ^designation.value = "Quality Control Metrics"
+
+* #"Sequencing-Data-Supplement" "Sequencing Data Supplement"
+* #"Sequencing-Data-Supplement" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Sequencing-Data-Supplement
+* #"Sequencing-Data-Supplement" ^designation.value = "Sequencing Data Supplement"
+
+* #"IGV" "IGV"
+* #"IGV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#IGV
+* #"IGV" ^designation.value = "IGV"

--- a/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh
+++ b/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh
@@ -55,9 +55,9 @@ Title: "Ferlab.bio CodeSystem/data-type"
 * #"Annotated-SNV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Annotated-SNV
 * #"Annotated-SNV" ^designation.value = "Annotated SNV"
 
-* #"QC-Metrics" "Quality Control Metrics"
-* #"QC-Metrics" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#QC-Metrics
-* #"QC-Metrics" ^designation.value = "Quality Control Metrics"
+* #"Quality-Control-Metrics" "Quality Control Metrics"
+* #"Quality-Control-Metrics" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Quality-Control-Metrics
+* #"Quality-Control-Metrics" ^designation.value = "Quality Control Metrics"
 
 * #"Sequencing-Data-Supplement" "Sequencing Data Supplement"
 * #"Sequencing-Data-Supplement" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Sequencing-Data-Supplement

--- a/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh
+++ b/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh
@@ -7,6 +7,10 @@ Title: "Ferlab.bio CodeSystem/document-format"
 * ^description = "Document format"
 * ^caseSensitive = true
 
+* #"FASTQ" "FASTQ File"
+* #"FASTQ" ^designation.language = #fr
+* #"FASTQ" ^designation.value = "FASTQ"
+
 * #"CRAM" "CRAM"
 * #"CRAM" ^designation.language = #fr
 * #"CRAM" ^designation.value = "CRAM"
@@ -27,10 +31,6 @@ Title: "Ferlab.bio CodeSystem/document-format"
 * #"VCF" ^designation.language = #fr
 * #"VCF" ^designation.value = "VCF"
 
-* #"TGZ" "TGZ Archive File"
-* #"TGZ" ^designation.language = #fr
-* #"TGZ" ^designation.value = "TGZ"
-
 * #"gVCF" "gVCF File"
 * #"gVCF" ^designation.language = #fr
 * #"gVCF" ^designation.value = "gVCF"
@@ -39,14 +39,14 @@ Title: "Ferlab.bio CodeSystem/document-format"
 * #"TBI" ^designation.language = #fr
 * #"TBI" ^designation.value = "TBI"
 
-* #"BW" "BW File"
-* #"BW" ^designation.language = #fr
-* #"BW" ^designation.value = "BW"
+* #"TGZ" "TGZ Archive File"
+* #"TGZ" ^designation.language = #fr
+* #"TGZ" ^designation.value = "TGZ"
+
+* #"bigWig" "bigWig File"
+* #"bigWig" ^designation.language = #fr
+* #"bigWig" ^designation.value = "bigWig"
 
 * #"BED" "BED File"
 * #"BED" ^designation.language = #fr
 * #"BED" ^designation.value = "BED"
-
-* #"FASTQ" "FASTQ File"
-* #"FASTQ" ^designation.language = #fr
-* #"FASTQ" ^designation.value = "FASTQ"

--- a/input/fsh/TaskResource/CQDG_Profile_Task_Example.fsh
+++ b/input/fsh/TaskResource/CQDG_Profile_Task_Example.fsh
@@ -35,11 +35,11 @@ Usage: #example
 * owner = Reference(Organization/OrganizationExample)
 * input.type.text = "Analysed sample"
 * input.valueReference = Reference(Specimen/SpecimenExample) "Submitter Sample ID: SpecimenExample"
-* output[0].type = https://fhir.cqdg.ca/CodeSystem/data-type#"Aligned-reads" "Aligned Reads"
+* output[0].type = https://fhir.cqdg.ca/CodeSystem/data-type#"Aligned-Reads" "Aligned Reads"
 * output[=].valueReference = Reference(DocumentReference/DocumentReferenceExample1)
 * output[+].type = https://fhir.cqdg.ca/CodeSystem/data-type#SNV "SNV"
 * output[=].valueReference = Reference(DocumentReference/DocumentReferenceExample1)
-* output[+].type = https://fhir.cqdg.ca/CodeSystem/data-type#"Germline-CNV" "Germline CNV"
+* output[+].type = https://fhir.cqdg.ca/CodeSystem/data-type#CNV "Copy Number Variations (CNVs)"
 * output[=].valueReference = Reference(DocumentReference/DocumentReferenceExample2)
-* output[+].type = https://fhir.cqdg.ca/CodeSystem/data-type#"Sequencing-data-supplement" "Sequencing-data-supplement"
+* output[+].type = https://fhir.cqdg.ca/CodeSystem/data-type#"Sequencing-Data-Supplement" "Sequencing Data Supplement"
 * output[=].valueReference = Reference(DocumentReference/DocumentReferenceExample2)

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_BioinfoAnalysisCode.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_BioinfoAnalysisCode.fsh
@@ -2,12 +2,10 @@ CodeSystem: BioinfoAnalysisCode
 Id: bioinfo-analysis-code
 Title: "Ferlab.bio CodeSystem/bioinformatics-analysis"
 
-
 * ^url = "https://fhir.cqdg.ca/CodeSystem/bioinfo-analysis-code"
 * ^experimental = false
 * ^description = "Bioinformatics analysis code"
 * ^caseSensitive = true
-
 
 * #"GBVA"  "Germline Variant Analysis"
 * #"GBVA"  ^designation.use = https://fhir.cqdg.ca/CodeSystem/bioinfo-analysis-code#GBVA // germline-variant-analysis


### PR DESCRIPTION
## Updated CodeSystems for DocumentReference

### Document Format CodeSystem
Updated `CQDG_CodeSystem_DocumentFormat.fsh` to include the following formats in order:
- FASTQ
- CRAM
- CRAI
- BAM
- BAI
- VCF
- gVCF
- TBI
- TGZ
- bigWig (replaced "BW")
- BED

### Data Type CodeSystem
Updated `CQDG_CodeSystem_DataType.fsh` to include 15 data types:
- Raw Sequencing Reads
- Raw Sequencing Reads R1
- Raw Sequencing Reads R2
- Aligned Reads
- Aligned Reads Index
- Single Nucleotide Variants (SNVs)
- Insertions and Deletions (InDels)
- Structural Variations (SVs)
- Copy Number Variations (CNVs)
- Variant Calls Index
- Joint Genotype SNV
- Annotated SNV
- Quality Control Metrics
- Sequencing Data Supplement
- IGV

#### Removed DataType
- Unaligned-Reads
- Germline-CNV
- Germline-structural-variant

### Changes Summary
- Replaced "Unaligned-Reads" with more specific "Raw-Sequencing-Reads" variants (R1/R2)
- Added new variant types (InDels, SVs)