### PR TITLE
feat: CQDG-1386 Added file md5 sum extension

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# Pull Request Title
+
+## 📌 Context
+
+<!-- Briefly describe the purpose of this PR. Include any relevant context. -->
+
+## 📝 Changes
+
+<!-- List the main changes in this PR. -->
+
+-
+
+## ☑️ TO-DOs
+
+<!-- Tasks that still need to be completed before merging. -->
+
+- [ ] 
+
+## 🧪 Tests
+
+<!-- Describe any new or updated tests, how to run them, and relevant results. -->
+
+-
+
+## 🔗 Related Issues
+
+<!-- Begin JIRA Issues -->
+
+<!-- End JIRA Issues -->
+
+## 👀 Notes for Reviewers
+
+<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->
+
+- 

--- a/fsh-generated/data/fsh-index.json
+++ b/fsh-generated/data/fsh-index.json
@@ -277,15 +277,15 @@
     "fshType": "Instance",
     "fshFile": "DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh",
     "startLine": 1,
-    "endLine": 22
+    "endLine": 23
   },
   {
     "outputFile": "DocumentReference-DocumentReferenceExample2.json",
     "fshName": "DocumentReferenceExample2",
     "fshType": "Instance",
     "fshFile": "DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh",
-    "startLine": 26,
-    "endLine": 44
+    "startLine": 27,
+    "endLine": 46
   },
   {
     "outputFile": "Group-CQDGGroupExample.json",
@@ -486,6 +486,14 @@
     "fshFile": "ResearchStudyResource/Extensions/CQDG_Extension_DataCollectionMethod.fsh",
     "startLine": 1,
     "endLine": 7
+  },
+  {
+    "outputFile": "StructureDefinition-FileMd5SumExtension.json",
+    "fshName": "FileMd5SumExtension",
+    "fshType": "Extension",
+    "fshFile": "DocumentReferenceResource/Extensions/CQDG_Extension_File-Md5-Sum.fsh",
+    "startLine": 1,
+    "endLine": 5
   },
   {
     "outputFile": "StructureDefinition-FullSizeExtension.json",

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -33,8 +33,8 @@ CodeSystem-study-design.json                                    StudyDesign     
 CodeSystem-tumor-normal-designation.json                        TumorNormalDesignationCodeSystem          CodeSystem  ObservationResource/CodeSystems/CQDG_CodeSystem_TumorNormalDesignationCodes.fsh   1 - 20
 CodeSystem-vital-status.json                                    VitalStatusCodeSystem                     CodeSystem  PatientResource/CodeSystems/CQDG_CodeSystem_VitalStatus.fsh                       1 - 22
 Condition-ConditionExample.json                                 ConditionExample                          Instance    ConditionResource/CQDG_Profile_Condition_Exemple.fsh                              1 - 28
-DocumentReference-DocumentReferenceExample1.json                DocumentReferenceExample1                 Instance    DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh              1 - 22
-DocumentReference-DocumentReferenceExample2.json                DocumentReferenceExample2                 Instance    DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh              26 - 44
+DocumentReference-DocumentReferenceExample1.json                DocumentReferenceExample1                 Instance    DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh              1 - 23
+DocumentReference-DocumentReferenceExample2.json                DocumentReferenceExample2                 Instance    DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh              27 - 46
 Group-CQDGGroupExample.json                                     CQDGGroupExample                          Instance    GroupResource/Examples/CQDG_Profile_Group_Example.fsh                             1 - 17
 List-ExampleCQDGProgramGroup.json                               ExampleCQDGProgramGroup                   Instance    ListProgram/Examples/CQDG_Profile_Program_Example.fsh                             1 - 57
 Observation-ObservationCauseOfDeathExample.json                 ObservationCauseOfDeathExample            Instance    ObservationResource/CQDG_Profile_Observation_Example.fsh                          43 - 56
@@ -60,6 +60,7 @@ StructureDefinition-CancerBiospecimenAnatomicLocation.json      CancerBiospecime
 StructureDefinition-CancerBiospecimenType.json                  CancerBiospecimenType                     Extension   SpecimenResource/Extensions/CQDG_Extension_CancerBiospecimenType.fsh              1 - 6
 StructureDefinition-DataCategoryExtension.json                  DataCategoryExtension                     Extension   ResearchStudyResource/Extensions/CQDG_Extension_DataCategory.fsh                  1 - 7
 StructureDefinition-DataCollectionMethodExtension.json          DataCollectionMethodExtension             Extension   ResearchStudyResource/Extensions/CQDG_Extension_DataCollectionMethod.fsh          1 - 7
+StructureDefinition-FileMd5SumExtension.json                    FileMd5SumExtension                       Extension   DocumentReferenceResource/Extensions/CQDG_Extension_File-Md5-Sum.fsh              1 - 5
 StructureDefinition-FullSizeExtension.json                      FullSizeExtension                         Extension   DocumentReferenceResource/Extensions/CQDG_Extension_Full-Size.fsh                 1 - 5
 StructureDefinition-Gender.json                                 Gender                                    Extension   PatientResource/Extensions/CQDG_Extension_Gender.fsh                              1 - 8
 StructureDefinition-QCEthnicity.json                            QCEthnicity                               Extension   PatientResource/Extensions/CQDG_Extension_QCEthnicity.fsh                         1 - 5

--- a/fsh-generated/includes/fsh-link-references.md
+++ b/fsh-generated/includes/fsh-link-references.md
@@ -60,6 +60,7 @@
 [DataCollectionMethodExtension]: StructureDefinition-DataCollectionMethodExtension.html
 [Dataset]: StructureDefinition-datasetExtension.html
 [ResearchStudyExpectedContent]: StructureDefinition-expectedStudyContent.html
+[FileMd5SumExtension]: StructureDefinition-FileMd5SumExtension.html
 [FullSizeExtension]: StructureDefinition-FullSizeExtension.html
 [Gender]: StructureDefinition-Gender.html
 [PopulationInfo]: StructureDefinition-population-info.html

--- a/fsh-generated/resources/DocumentReference-DocumentReferenceExample1.json
+++ b/fsh-generated/resources/DocumentReference-DocumentReferenceExample1.json
@@ -18,6 +18,10 @@
         "extension": [
           {
             "url": "https://fhir.cqdg.ca/StructureDefinition/FullSizeExtension"
+          },
+          {
+            "url": "https://fhir.cqdg.ca/StructureDefinition/FileMd5SumExtension",
+            "valueString": "5d41402abc4b2a76b9719d911017c592"
           }
         ],
         "contentType": "application/octet-stream",

--- a/fsh-generated/resources/DocumentReference-DocumentReferenceExample2.json
+++ b/fsh-generated/resources/DocumentReference-DocumentReferenceExample2.json
@@ -15,6 +15,10 @@
           {
             "url": "https://fhir.cqdg.ca/StructureDefinition/FullSizeExtension",
             "valueDecimal": 22799222
+          },
+          {
+            "url": "https://fhir.cqdg.ca/StructureDefinition/FileMd5SumExtension",
+            "valueString": "098f6bcd4621d373cade4e832627b4f6"
           }
         ],
         "contentType": "application/octet-stream",

--- a/fsh-generated/resources/ImplementationGuide-fhir.cqdg.json
+++ b/fsh-generated/resources/ImplementationGuide-fhir.cqdg.json
@@ -529,6 +529,14 @@
       },
       {
         "reference": {
+          "reference": "StructureDefinition/FileMd5SumExtension"
+        },
+        "name": "Ferlab.bio Extension/file-md5-sum",
+        "description": "File MD5 Sum Extension",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "StructureDefinition/FullSizeExtension"
         },
         "name": "Ferlab.bio Extension/full-size",

--- a/fsh-generated/resources/StructureDefinition-FileMd5SumExtension.json
+++ b/fsh-generated/resources/StructureDefinition-FileMd5SumExtension.json
@@ -1,0 +1,36 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "FileMd5SumExtension",
+  "url": "https://fhir.cqdg.ca/StructureDefinition/FileMd5SumExtension",
+  "name": "FileMd5SumExtension",
+  "title": "Ferlab.bio Extension/file-md5-sum",
+  "status": "active",
+  "description": "File MD5 Sum Extension",
+  "fhirVersion": "4.0.1",
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Element"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "Ferlab.bio Extension/file-md5-sum",
+        "definition": "File MD5 Sum Extension"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "https://fhir.cqdg.ca/StructureDefinition/FileMd5SumExtension"
+      }
+    ]
+  }
+}

--- a/input/fsh/DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh
+++ b/input/fsh/DocumentReferenceResource/CQDG_Profile_DocumentReference_Exemple.fsh
@@ -15,6 +15,7 @@ Usage: #example
 * category = https://fhir.cqdg.ca/CodeSystem/data-category#genomics "Genomics"
 * subject = Reference(Patient/PatientExample)
 * content.attachment.extension[FullSizeExtension].valueDecimal
+* content.attachment.extension[FileMd5SumExtension].valueString = "5d41402abc4b2a76b9719d911017c592"
 * content.attachment.contentType = #application/octet-stream
 * content.attachment.url = "https://ferload.qa.cqgc.hsj.rtss.qc.ca/blue/0cdf0811-d528-466b-9b55-1abcbfc9f681"
 * content.format = https://fhir.cqdg.ca/CodeSystem/document-format#TGZ "TGZ Archive File"
@@ -38,6 +39,7 @@ Usage: #example
 * category = https://fhir.cqdg.ca/CodeSystem/data-category#genomics "Genomics"
 * subject = Reference(Patient/PatientExample)
 * content.attachment.extension[FullSizeExtension].valueDecimal = 22799222
+* content.attachment.extension[FileMd5SumExtension].valueString = "098f6bcd4621d373cade4e832627b4f6"
 * content.attachment.contentType = #application/octet-stream
 * content.attachment.url = "https://ferload.qa.cqgc.hsj.rtss.qc.ca/blue/0cdf0811-d528-466b-9b55-1abcbfc9f681"
 * content.format = https://fhir.cqdg.ca/CodeSystem/document-format#TGZ "TGZ Archive File"

--- a/input/fsh/DocumentReferenceResource/Extensions/CQDG_Extension_File-Md5-Sum.fsh
+++ b/input/fsh/DocumentReferenceResource/Extensions/CQDG_Extension_File-Md5-Sum.fsh
@@ -1,0 +1,5 @@
+Extension: FileMd5SumExtension
+Id: FileMd5SumExtension
+Description: "File MD5 Sum Extension"
+Title: "Ferlab.bio Extension/file-md5-sum"
+* valueString


### PR DESCRIPTION
## 📌 Context

This PR adds the `FileMd5SumExtension` to the `DocumentReferenceResource`. Its value will then be assigned in the FHIR import. The value is a simple string. This will replace the usage of the built-in `attachement.hash` since it must not be base64 encoded.

## 📝 Changes

- Added `FileMd5SumExtension` to the `DocumentReferenceResource` resource
- Added `FileMd5SumExtension` to the `DocumentReferenceResource` examples

## 🔗 Related Issues

- [CQDG-1386](https://ferlab-crsj.atlassian.net/browse/CQDG-1386?atlOrigin=eyJpIjoiZmY5ZDllMGVjOTdkNGRhNmE1Y2Y5ZTliNDRjMDVjYzEiLCJwIjoiaiJ9)
- [CQDG-1385](https://ferlab-crsj.atlassian.net/browse/CQDG-1385?atlOrigin=eyJpIjoiZGQxZTlhMDcyMTI1NGQ4NGJmY2U0MDk1MjI3NDZlZTkiLCJwIjoiaiJ9)

[CQDG-1386]: https://ferlab-crsj.atlassian.net/browse/CQDG-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CQDG-1385]: https://ferlab-crsj.atlassian.net/browse/CQDG-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ