### PR TITLE
feat: CQDG-1390 Added GRCh37 genome build code system

### DIFF
--- a/fsh-generated/data/fsh-index.json
+++ b/fsh-generated/data/fsh-index.json
@@ -141,7 +141,7 @@
     "fshType": "CodeSystem",
     "fshFile": "TaskResource/CodeSystems/CQDG_CodeSystem_GenomeBuild.fsh",
     "startLine": 1,
-    "endLine": 12
+    "endLine": 16
   },
   {
     "outputFile": "CodeSystem-population.json",

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -16,7 +16,7 @@ CodeSystem-duo-codes.json                                       DUOCodes        
 CodeSystem-experimental-strategy.json                           ExperimentalStrategy                      CodeSystem  TaskResource/CodeSystems/CQDG_CodeSystem_ExperimentalStrategy.fsh                 1 - 68
 CodeSystem-family-type.json                                     FamilyType                                CodeSystem  GroupResource/CodeSystems/CQDG_CodeSystem_FamilyType.fsh                          1 - 24
 CodeSystem-gender-collection-method.json                        GenderCollectionMethod                    CodeSystem  PatientResource/CodeSystems/CQDG_CodeSystem_GenderCollectionMethod.fsh            1 - 20
-CodeSystem-genome-build.json                                    GenomeBuild                               CodeSystem  TaskResource/CodeSystems/CQDG_CodeSystem_GenomeBuild.fsh                          1 - 12
+CodeSystem-genome-build.json                                    GenomeBuild                               CodeSystem  TaskResource/CodeSystems/CQDG_CodeSystem_GenomeBuild.fsh                          1 - 16
 CodeSystem-population.json                                      Population                                CodeSystem  ResearchStudyResource/CodeSystem/CQDG_CodeSystem_Population.fsh                   1 - 16
 CodeSystem-qc-ethnicity.json                                    QCEthnicityCodeSystem                     CodeSystem  PatientResource/CodeSystems/CQDG_CodeSystem_Ethnicity.fsh                         1 - 52
 CodeSystem-qc-gender.json                                       QCGender                                  CodeSystem  PatientResource/CodeSystems/CQDG_CodeSystem_Gender.fsh                            2 - 45

--- a/fsh-generated/resources/CodeSystem-genome-build.json
+++ b/fsh-generated/resources/CodeSystem-genome-build.json
@@ -8,6 +8,19 @@
   "url": "https://fhir.cqdg.ca/CodeSystem/genome-build",
   "concept": [
     {
+      "code": "GRCh37",
+      "display": "GRCh37",
+      "designation": [
+        {
+          "use": {
+            "code": "GRCh37",
+            "system": "https://fhir.cqdg.ca/CodeSystem/genome-build"
+          },
+          "value": "GRCh37"
+        }
+      ]
+    },
+    {
       "code": "GRCh38",
       "display": "GRCh38",
       "designation": [
@@ -24,5 +37,5 @@
   "experimental": false,
   "description": "Genome build",
   "caseSensitive": true,
-  "count": 1
+  "count": 2
 }

--- a/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_GenomeBuild.fsh
+++ b/input/fsh/TaskResource/CodeSystems/CQDG_CodeSystem_GenomeBuild.fsh
@@ -7,6 +7,10 @@ Title: "Ferlab.bio CodeSystem/genome-build"
 * ^description = "Genome build"
 * ^caseSensitive = true
 
+* #"GRCh37" "GRCh37"
+* #"GRCh37" ^designation.use = https://fhir.cqdg.ca/CodeSystem/genome-build#GRCh37
+* #"GRCh37" ^designation.value = "GRCh37"
+
 * #"GRCh38" "GRCh38"
 * #"GRCh38" ^designation.use = https://fhir.cqdg.ca/CodeSystem/genome-build#GRCh38
 * #"GRCh38" ^designation.value = "GRCh38"


### PR DESCRIPTION
## 📌 Context

This PR adds missing GRCh37 code system for genome build.

## 🔗 Related Issues

- [CQDG-1390](https://ferlab-crsj.atlassian.net/browse/CQDG-1390?atlOrigin=eyJpIjoiOWM0OGU4OGY1ZTM4NDU0Nzk3MjA2NTJlOGZhNmY1MWIiLCJwIjoiaiJ9)

[CQDG-1390]: https://ferlab-crsj.atlassian.net/browse/CQDG-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ