### PR TITLE
fix: CQDG-1403 Added support for csv files

### DIFF
--- a/fsh-generated/data/fsh-index.json
+++ b/fsh-generated/data/fsh-index.json
@@ -85,7 +85,7 @@
     "fshType": "CodeSystem",
     "fshFile": "DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh",
     "startLine": 1,
-    "endLine": 68
+    "endLine": 72
   },
   {
     "outputFile": "CodeSystem-disease-status.json",
@@ -101,7 +101,7 @@
     "fshType": "CodeSystem",
     "fshFile": "DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh",
     "startLine": 1,
-    "endLine": 52
+    "endLine": 56
   },
   {
     "outputFile": "CodeSystem-duo-codes.json",

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -9,9 +9,9 @@ CodeSystem-cqdg-study-cs.json                                   CQDGStudyCS     
 CodeSystem-cqdg-tumor-normal-designation.json                   CQDGTumorNormalDesignationCodeSystem      CodeSystem  SpecimenResource/CodeSytem/CQDG_CodeSystem_TumorNormalDesignation.fsh             1 - 11
 CodeSystem-data-category.json                                   DataCategory                              CodeSystem  Common/CQDG_CodeSystem_DataCategory.fsh                                           1 - 43
 CodeSystem-data-collection-method.json                          DataCollectionMethod                      CodeSystem  ResearchStudyResource/CodeSystem/CQDG_CodeSystem_DataCollectionMethod.fsh         1 - 23
-CodeSystem-data-type.json                                       DataType                                  CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh                1 - 68
+CodeSystem-data-type.json                                       DataType                                  CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh                1 - 72
 CodeSystem-disease-status.json                                  DiseaseStatusCS                           CodeSystem  ObservationResource/CodeSystems/CQDG_CodeSystem_DiseaseStatus.fsh                 1 - 20
-CodeSystem-document-format.json                                 DocumentFormat                            CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh          1 - 52
+CodeSystem-document-format.json                                 DocumentFormat                            CodeSystem  DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh          1 - 56
 CodeSystem-duo-codes.json                                       DUOCodes                                  CodeSystem  ResearchStudyResource/CodeSystem/CQDG_CodeSystem_DUOCodes.fsh                     1 - 78
 CodeSystem-experimental-strategy.json                           ExperimentalStrategy                      CodeSystem  TaskResource/CodeSystems/CQDG_CodeSystem_ExperimentalStrategy.fsh                 1 - 68
 CodeSystem-family-type.json                                     FamilyType                                CodeSystem  GroupResource/CodeSystems/CQDG_CodeSystem_FamilyType.fsh                          1 - 24

--- a/fsh-generated/resources/CodeSystem-data-type.json
+++ b/fsh-generated/resources/CodeSystem-data-type.json
@@ -201,10 +201,23 @@
           "value": "IGV"
         }
       ]
+    },
+    {
+      "code": "Laboratory-Values",
+      "display": "Laboratory Values",
+      "designation": [
+        {
+          "use": {
+            "code": "Laboratory-Values",
+            "system": "https://fhir.cqdg.ca/CodeSystem/data-type"
+          },
+          "value": "Laboratory Values"
+        }
+      ]
     }
   ],
   "experimental": false,
   "description": "Data Type",
   "caseSensitive": true,
-  "count": 15
+  "count": 16
 }

--- a/fsh-generated/resources/CodeSystem-document-format.json
+++ b/fsh-generated/resources/CodeSystem-document-format.json
@@ -116,10 +116,20 @@
           "value": "BED"
         }
       ]
+    },
+    {
+      "code": "CSV",
+      "display": "CSV File",
+      "designation": [
+        {
+          "language": "fr",
+          "value": "CSV"
+        }
+      ]
     }
   ],
   "experimental": false,
   "description": "Document format",
   "caseSensitive": true,
-  "count": 11
+  "count": 12
 }

--- a/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh
+++ b/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DataType.fsh
@@ -66,3 +66,7 @@ Title: "Ferlab.bio CodeSystem/data-type"
 * #"IGV" "IGV"
 * #"IGV" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#IGV
 * #"IGV" ^designation.value = "IGV"
+
+* #"Laboratory-Values" "Laboratory Values"
+* #"Laboratory-Values" ^designation.use = https://fhir.cqdg.ca/CodeSystem/data-type#Laboratory-Values
+* #"Laboratory-Values" ^designation.value = "Laboratory Values"

--- a/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh
+++ b/input/fsh/DocumentReferenceResource/CodeSystems/CQDG_CodeSystem_DocumentFormat.fsh
@@ -50,3 +50,7 @@ Title: "Ferlab.bio CodeSystem/document-format"
 * #"BED" "BED File"
 * #"BED" ^designation.language = #fr
 * #"BED" ^designation.value = "BED"
+
+* #"CSV" "CSV File"
+* #"CSV" ^designation.language = #fr
+* #"CSV" ^designation.value = "CSV"


### PR DESCRIPTION
## 📌 Context

This PR adds support for CSV files by adding the `CSV` code to `DocumentFormat` and `Laboratory-Values` code to `DataType`.

## 🔗 Related Issues

- [CQDG-1403](https://ferlab-crsj.atlassian.net/browse/CQDG-1403)

[CQDG-1403]: https://ferlab-crsj.atlassian.net/browse/CQDG-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ